### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ public class MyGame extends Game {
         Sound mySound = Gdx.audio.newSound(Gdx.files.internal("path/to/sound.wav"));
         
         // Play your sounds through Boom
-        boom.play(sound, myChannel);
+        boom.play(mySound, myChannel);
     }
 }
 ```


### PR DESCRIPTION
The Sound variable name was inconsistent, it was named mySound then called in the example as sound. this was fixed.