### PR TITLE
Fix fetchMaxAuxiliarySends returning false values on error

### DIFF
--- a/lwjgl3/src/main/java/com/rafaskoberg/boom/BoomLwjgl3.java
+++ b/lwjgl3/src/main/java/com/rafaskoberg/boom/BoomLwjgl3.java
@@ -77,7 +77,6 @@ public class BoomLwjgl3 extends Boom {
 
     private static int fetchMaxAuxiliarySends() {
         final int desiredAmount = 16;
-        final int fallbackAmount = 2;
 
         // Get device handle
         long deviceHandle = getDeviceHandle(); // Will be 0 in case of errors
@@ -92,7 +91,6 @@ public class BoomLwjgl3 extends Boom {
         // Reset the audio device with the new attributes
         if(!SOFTHRTF.alcResetDeviceSOFT(deviceHandle, contextAttributes)) {
             Gdx.app.error("Boom", String.format("Couldn't reset device with new effect slot limit attributes. deviceHandle: %d, error: %d", deviceHandle, ALC10.alcGetError(deviceHandle)));
-            return fallbackAmount;
         }
 
         // Check how many effect slots we got


### PR DESCRIPTION
It is not sure that there are 2 auxiliary sends in case of an error (AL might change its default value, libgdx might request something different, or the default 2 might have not been granted by AL in the first place). All reasons are pretty unlikely but the implementation is more robust/correct when asking OpenAL for the actual value.

If that also goes wrong because the deviceHandle could not be determined, there is a big error case anyway which prevents Boom or audio in general from working correctly. In this respect I do not think that such an error should be concealed by simply assuming that there are 2 auxiliary sends.

Of course you could still check deviceHandle for validity or do error handling, even if it's just throwing an exception... but this is out of the scope of this PR.